### PR TITLE
use ansible host before inventory_hostname

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -3,8 +3,8 @@
   delegate_to: "{{ groups['prometheus'][0] }}"
   blockinfile:
     dest: "{{ prometheus_config }}"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ inventory_hostname }}:{{ exporter_port }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ ansible_host|default(inventory_hostname) }}:{{ exporter_port }}"
     block: |
        - targets:
-           - {{ inventory_hostname }}:{{ exporter_port }}
+           - {{ ansible_host|default(inventory_hostname) }}:{{ exporter_port }}
 ...


### PR DESCRIPTION
Still fallback to inventory_hostname, but since ansible_host is more garunteed to be routable, we should prefer that. inventory_hostname can be a dummy name like:

[mygroup]
myhost1 ansible_host=10.10.123.12