### PR TITLE
use hostvar ansible_host if defined

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -3,7 +3,7 @@
   delegate_to: "{{ groups['prometheus'][0] }}"
   blockinfile:
     dest: "{{ prometheus_config }}"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ ansible_host|default(inventory_hostname) }}:{{ exporter_port }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK for {{ hostvar['ansible_host']|default(inventory_hostname) }}:{{ exporter_port }}"
     block: |
        - targets:
            - {{ ansible_host|default(inventory_hostname) }}:{{ exporter_port }}


### PR DESCRIPTION
Turns out the bare ansible_host var will resolve differently, and can
end up being the delegate_to host. We just want to support a explicit
ansible_host hostvar. Thanks to Nikhil for figuring this out.